### PR TITLE
Strip httpretty requirement from requirements.txt

### DIFF
--- a/recipe/httpretty.patch
+++ b/recipe/httpretty.patch
@@ -1,0 +1,8 @@
+--- requirements.txt.orig	2017-04-18 08:47:15.876571289 -0400
++++ requirements.txt	2017-04-18 08:47:19.785593302 -0400
+@@ -1,5 +1,4 @@
+ six
+ requests
+-httpretty==0.8.10
+ werkzeug
+ mock

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,9 +10,11 @@ source:
   fn: {{ name }}-{{ version }}.tar.gz
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: {{ sha256 }}
+  patches:
+    - httpretty.patch
 
 build:
-  number: 0
+  number: 1
   script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:


### PR DESCRIPTION
It's only used for testing, and the version pin causes problems since conda(-forge) doesn't
provide that exact version. And httpretty is only compatible with Python 2. This was
causing problems for the 'astrocats' package since the httpretty requirement would get
processed by pip on 'setup.py install'.